### PR TITLE
onUncaughtException should accept \Throwable instead of \Exception

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,6 +7,7 @@
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql` Tinyint(1) is handled as boolean under MySql [#14708](https://github.com/phalcon/cphalcon/issues/14708)
 - Fixed `Phalcon\Mvc\View\Engine\Volt` to produce the correct order of variables for the `join` filter [#14771](https://github.com/phalcon/cphalcon/issues/14771)
 - Fixed `Phalcon\Storage\Adapter\Stream::getKeys()` bug in the absence of a directory with a prefix name [#14725](https://github.com/phalcon/cphalcon/issues/14725), [#14721](https://github.com/phalcon/cphalcon/pull/14721)
+- Fixed `Phalcon\Debug::onUncaughtException` Should accept `\Throwable` instead of `\Exception` as an argument [#14738](https://github.com/phalcon/cphalcon/pull/14738)
 
 # [4.0.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.1) (2020-01-11)
 

--- a/phalcon/Debug.zep
+++ b/phalcon/Debug.zep
@@ -197,7 +197,7 @@ class Debug
     /**
      * Handles uncaught exceptions
      */
-    public function onUncaughtException(<\Exception> exception) -> bool
+    public function onUncaughtException(<\Throwable> exception) -> bool
     {
         var blacklist, className, dataVar, dataVars, escapedMessage, html,
             keyFile, keyRequest, keyServer, keyVar, n, showBackTrace, traceItem,


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

As of support for php 7.x and introdyction of \Throwable, Phalcon debug method of `onUncaughtException` should accept `\Throwable` instead of `\Exception`

Thanks

